### PR TITLE
corresponding to NGT v1.4.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME := gongt
-VERSION := v0.0.1
+VERSION := v0.0.2
 GO_VERSION := $(shell go version)
 REVISION := $(shell git rev-parse --short HEAD)
 PROJECT_ROOT := $(shell pwd)

--- a/gongt.go
+++ b/gongt.go
@@ -387,7 +387,7 @@ func (n *NGT) Open() *NGT {
 	n.index = C.ngt_open_index(C.CString(n.prop.IndexPath), ebuf)
 	if n.index == nil {
 		err := newGoError(ebuf)
-		if strings.Contains(err.Error(), "PropertSet::load: Cannot load the property file ") {
+		if strings.Contains(err.Error(), "PropertySet::load: Cannot load the property file ") {
 			n.index = C.ngt_create_graph_and_tree(C.CString(n.prop.IndexPath), prop, ebuf)
 			if n.index == nil {
 				n.errs = append(n.errs, newGoError(ebuf))

--- a/gongt.go
+++ b/gongt.go
@@ -387,7 +387,7 @@ func (n *NGT) Open() *NGT {
 	n.index = C.ngt_open_index(C.CString(n.prop.IndexPath), ebuf)
 	if n.index == nil {
 		err := newGoError(ebuf)
-		if strings.Contains(err.Error(), "PropertySet::load: Cannot load the property file ") {
+		if strings.Contains(err.Error(), "PropertySet::load: Cannot load the property file ") || strings.Contains(err.Error(), "PropertSet::load: Cannot load the property file ") {
 			n.index = C.ngt_create_graph_and_tree(C.CString(n.prop.IndexPath), prop, ebuf)
 			if n.index == nil {
 				n.errs = append(n.errs, newGoError(ebuf))


### PR DESCRIPTION
Update gongt for NGT v1.4.5.

Using NGT v1.4.5,  gongt cannot create new index.
This PR fixes checking error message from NGT.
