### PR TITLE
[minor] add radius argument to StrictSearch function for user custom radius search

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ alias:
           GOPATH: "/go"
           GO111MODULE: "on"
           LD_LIBRARY_PATH: /usr/local/lib
-          NGT_VERSION: 1.6.1
+          NGT_VERSION: 1.7.0
           REPO_NAME: "yahoojapan"
           IMAGE_NAME: "gongt"
           GITHUB_API: "https://api.github.com/"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/yahoojapan/gongt
 
+go 1.12
+
 require (
-	github.com/kpango/glg v1.2.7
-	gonum.org/v1/hdf5 v0.0.0-20180702054324-c257073619f4
+	github.com/kpango/glg v1.3.0
+	gonum.org/v1/hdf5 v0.0.0-20190227001252-83207889d689
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/kpango/fastime v1.0.0 h1:tZeI+eEyHHYKkTkKOiOZ5MeeRJmliuZlGV7aK7S2rkE=
-github.com/kpango/fastime v1.0.0/go.mod h1:Y5XY5bLG5yc7g2XmMUzc22XYV1XaH+KgUOHkDvLp4SA=
-github.com/kpango/glg v1.2.7 h1:aVnv89IIWXSFNOm93SnDQGIKF27Jzz9olieOL2b23Xc=
-github.com/kpango/glg v1.2.7/go.mod h1:sEwy6Va116x0eKdbVsilHPanIrsoE9AR/9vHwdo4ytQ=
-gonum.org/v1/hdf5 v0.0.0-20180702054324-c257073619f4 h1:3GnLlVt6JOlXwffishXEToqGjH7hx/G8UK7RP7HTqX0=
-gonum.org/v1/hdf5 v0.0.0-20180702054324-c257073619f4/go.mod h1:g+PDU5ogjIKcc3Cg4ALAK7X4c8bBQvPzPKWNW5NB7I0=
+github.com/kpango/fastime v1.0.8 h1:Wif5eocdsIXmMG+8HHfRP/jD6UUl+/OVTJ+sMzvA1+E=
+github.com/kpango/fastime v1.0.8/go.mod h1:Y5XY5bLG5yc7g2XmMUzc22XYV1XaH+KgUOHkDvLp4SA=
+github.com/kpango/glg v1.3.0 h1:77BWdR0kKkFloM2eSAr0A7lWvUyAIlOhj4LV5n2hrB8=
+github.com/kpango/glg v1.3.0/go.mod h1:7zzaAoMqvngad+sagWLjr00EQMJaqyGONdg0WYBAO3M=
+gonum.org/v1/hdf5 v0.0.0-20190227001252-83207889d689 h1:kkaDDDkZcDezmnomcLvU906I4tjWroioOqEzkFIg/T8=
+gonum.org/v1/hdf5 v0.0.0-20190227001252-83207889d689/go.mod h1:g+PDU5ogjIKcc3Cg4ALAK7X4c8bBQvPzPKWNW5NB7I0=

--- a/gongt.go
+++ b/gongt.go
@@ -445,12 +445,12 @@ func (n *NGT) Open() *NGT {
 }
 
 // StrictSearch is C type stricted search function
-func StrictSearch(vec []float64, size int, epsilon float32) ([]StrictSearchResult, error) {
-	return ngt.StrictSearch(vec, size, epsilon)
+func StrictSearch(vec []float64, size int, epsilon, radius float32) ([]StrictSearchResult, error) {
+	return ngt.StrictSearch(vec, size, epsilon, radius)
 }
 
 // StrictSearch is C type stricted search function
-func (n *NGT) StrictSearch(vec []float64, size int, epsilon float32) ([]StrictSearchResult, error) {
+func (n *NGT) StrictSearch(vec []float64, size int, epsilon, radius float32) ([]StrictSearchResult, error) {
 	ebuf := C.ngt_create_error_object()
 	defer C.ngt_destroy_error_object(ebuf)
 
@@ -461,7 +461,7 @@ func (n *NGT) StrictSearch(vec []float64, size int, epsilon float32) ([]StrictSe
 	}
 
 	n.mu.RLock()
-	ret := C.ngt_search_index(n.index, (*C.double)(&vec[0]), C.int32_t(n.prop.Dimension), C.size_t(size), C.float(epsilon), results, ebuf)
+	ret := C.ngt_search_index(n.index, (*C.double)(&vec[0]), C.int32_t(n.prop.Dimension), C.size_t(size), C.float(epsilon), C.float(radius), results, ebuf)
 	n.mu.RUnlock()
 	if ret == ErrorCode {
 		return nil, newGoError(ebuf)
@@ -490,7 +490,7 @@ func Search(vec []float64, size int, epsilon float64) ([]SearchResult, error) {
 
 // Search returns search result as []SearchResult
 func (n *NGT) Search(vec []float64, size int, epsilon float64) ([]SearchResult, error) {
-	res, err := n.StrictSearch(vec, size, float32(epsilon))
+	res, err := n.StrictSearch(vec, size, float32(epsilon), -1.0)
 	if err != nil {
 		return nil, err
 	}

--- a/gongt_example_test.go
+++ b/gongt_example_test.go
@@ -197,7 +197,7 @@ func ExampleNGT_Open() {
 func ExampleStrictSearch() {
 	// Strict Vector Search
 	vector := []float64{1, 0, 0, 0, 0, 0}
-	res, err := gongt.StrictSearch(vector, 1, gongt.DefaultEpsilon)
+	res, err := gongt.StrictSearch(vector, 1, gongt.DefaultEpsilon, 1.1)
 	// Output:
 	_, _ = res, err
 }
@@ -205,7 +205,7 @@ func ExampleStrictSearch() {
 func ExampleNGT_StrictSearch() {
 	// Strict Vector Search
 	vector := []float64{1, 0, 0, 0, 0, 0}
-	res, err := gongt.Get().StrictSearch(vector, 1, gongt.DefaultEpsilon)
+	res, err := gongt.Get().StrictSearch(vector, 1, gongt.DefaultEpsilon, 0.9)
 	// Output:
 	//
 	_, _ = res, err

--- a/gongt_test.go
+++ b/gongt_test.go
@@ -277,7 +277,7 @@ func TestStrictSearch(t *testing.T) {
 		t.Errorf("Unexpected error: TestStrictSearch(%v)", errs)
 	}
 	for _, tt := range tests {
-		result, err := ngt.StrictSearch(tt.vector, 1, DefaultEpsilon)
+		result, err := ngt.StrictSearch(tt.vector, 1, DefaultEpsilon, -1.0)
 		if err != nil {
 			t.Errorf("Unexpected error: TestSearch(%v)", err)
 		}


### PR DESCRIPTION
add radius argument to StrictSearch function

before
```
func StrictSearch(vec []float64, size int, epsilon float32) ([]StrictSearchResult, error)
```

after
```
func StrictSearch(vec []float64, size int, epsilon, radius float32) ([]StrictSearchResult, error)
```

#7 is now resolved by this PR